### PR TITLE
[WIP] Use a single HTTP Client

### DIFF
--- a/src/SparkPost.Tests/RequestSenders/AsyncRequestSenderTests.cs
+++ b/src/SparkPost.Tests/RequestSenders/AsyncRequestSenderTests.cs
@@ -76,59 +76,6 @@ namespace SparkPost.Tests.RequestSenders
                 result.Content.ShouldEqual(content);
             }
 
-            [Test]
-            public async void It_should_pass_the_api_key()
-            {
-                Subject.SetupTheResponseWith((r, h) =>
-                {
-                    h.DefaultRequestHeaders.Authorization.ToString().ShouldEqual(apiKey);
-                    return defaultHttpResponseMessage;
-                });
-
-                await Subject.Send(request);
-            }
-
-            [Test]
-            public async void It_should_send_the_request_to_the_appropriate_host()
-            {
-                Subject.SetupTheResponseWith((r, h) =>
-                {
-                    h.BaseAddress.ToString().ShouldEqual(apiHost + "/");
-                    return defaultHttpResponseMessage;
-                });
-
-                await Subject.Send(request);
-            }
-
-            [Test]
-            public async void It_should_set_the_subaccount_when_the_subaccount_is_not_zero()
-            {
-                Mocked<IClient>().Setup(x => x.SubaccountId).Returns(345);
-                Subject.SetupTheResponseWith((r, h) =>
-                {
-                    var match = h.DefaultRequestHeaders.First(x => x.Key == "X-MSYS-SUBACCOUNT");
-                    match.Value.Count().ShouldEqual(1);
-                    match.Value.First().ShouldEqual("345");
-                    return defaultHttpResponseMessage;
-                });
-
-                await Subject.Send(request);
-            }
-
-            [Test]
-            public async void It_should_NOT_set_a_subaccount_when_the_subaccount_is_zero()
-            {
-                Mocked<IClient>().Setup(x => x.SubaccountId).Returns(0);
-                Subject.SetupTheResponseWith((r, h) =>
-                {
-                    var count = h.DefaultRequestHeaders.Count(x => x.Key == "X-MSYS-SUBACCOUNT");
-                    count.ShouldEqual(0);
-                    return defaultHttpResponseMessage;
-                });
-
-                await Subject.Send(request);
-            }
-
             public class AsyncTesting : AsyncRequestSender
             {
                 private Func<Request, HttpClient, HttpResponseMessage> responseBuilder;

--- a/src/SparkPost.Tests/RequestSenders/AsyncRequestSenderTests.cs
+++ b/src/SparkPost.Tests/RequestSenders/AsyncRequestSenderTests.cs
@@ -28,6 +28,8 @@ namespace SparkPost.Tests.RequestSenders
 
                 httpClient = new HttpClient();
 
+                Mocker.SetInstance(httpClient);
+
                 apiHost = "http://test.com";
                 apiKey = Guid.NewGuid().ToString();
 
@@ -131,7 +133,7 @@ namespace SparkPost.Tests.RequestSenders
             {
                 private Func<Request, HttpClient, HttpResponseMessage> responseBuilder;
 
-                public AsyncTesting(IClient client) : base(client, null)
+                public AsyncTesting(IClient client, Func<HttpClient> httpClient) : base(client, null, httpClient)
                 {
                 }
 

--- a/src/SparkPost.Tests/RequestSenders/AsyncRequestSenderTests.cs
+++ b/src/SparkPost.Tests/RequestSenders/AsyncRequestSenderTests.cs
@@ -80,7 +80,7 @@ namespace SparkPost.Tests.RequestSenders
             {
                 private Func<Request, HttpClient, HttpResponseMessage> responseBuilder;
 
-                public AsyncTesting(IClient client, Func<HttpClient> httpClient) : base(client, null, httpClient)
+                public AsyncTesting(IClient client, Func<HttpClient> httpClient) : base(null, httpClient)
                 {
                 }
 

--- a/src/SparkPost.Tests/RequestSenders/RequestSenderTests.cs
+++ b/src/SparkPost.Tests/RequestSenders/RequestSenderTests.cs
@@ -22,7 +22,7 @@ namespace SparkPost.Tests.RequestSenders
 
                 request = new Request();
 
-                async = new Mock<AsyncRequestSender>(null, null);
+                async = new Mock<AsyncRequestSender>(null, null, null);
                 sync = new Mock<SyncRequestSender>(null);
 
                 Mocker.SetInstance<IClient>(client);

--- a/src/SparkPost.Tests/SparkPost.Tests.csproj
+++ b/src/SparkPost.Tests/SparkPost.Tests.csproj
@@ -101,6 +101,7 @@
     <Compile Include="RequestSenders\SyncRequestSenderTests.cs" />
     <Compile Include="TransmissionTests.cs" />
     <Compile Include="SubaccountTest.cs" />
+    <Compile Include="Utilities\HttpClientPreparationTests.cs" />
     <Compile Include="Utilities\SnakeCaseTests.cs" />
     <Compile Include="RelayWebhookTests.cs" />
     <Compile Include="WebhookTests.cs" />

--- a/src/SparkPost.Tests/Utilities/HttpClientPreparationTests.cs
+++ b/src/SparkPost.Tests/Utilities/HttpClientPreparationTests.cs
@@ -1,0 +1,79 @@
+﻿using System;
+using System.Linq;
+using System.Net.Http;
+using AutoMoq.Helpers;
+using NUnit.Framework;
+using Should;
+
+namespace SparkPost.Tests.Utilities
+{
+    public class HttpClientPreparationTests
+    {
+        [TestFixture]
+        public class PrepareTests : AutoMoqTestFixture<HttpClientPreparation>
+        {
+            private HttpClient httpClient;
+            private string apiHost;
+            private string apiKey;
+
+            [SetUp]
+            public void Setup()
+            {
+                ResetSubject();
+
+                httpClient = new HttpClient();
+
+                apiHost = "http://test.com";
+                apiKey = Guid.NewGuid().ToString();
+
+                var settings = new Client.Settings();
+                settings.BuildHttpClientsUsing(() => httpClient);
+                Mocked<IClient>().Setup(x => x.CustomSettings).Returns(settings);
+                Mocked<IClient>().Setup(x => x.ApiHost).Returns(apiHost);
+                Mocked<IClient>().Setup(x => x.ApiKey).Returns(apiKey);
+            }
+
+            [Test]
+            public void It_should_set_the_base_address()
+            {
+                Subject.Prepare(httpClient);
+                httpClient.BaseAddress.Host.ShouldEqual("test.com");
+            }
+
+            [Test]
+            public void It_should_set_the_authorization_header()
+            {
+                Subject.Prepare(httpClient);
+                httpClient.DefaultRequestHeaders.Authorization.ToString().ShouldEqual(apiKey);
+            }
+
+            [Test]
+            public void It_should_set_the_x_msys_subaccount_if_the_subaccount_is_set()
+            {
+                Mocked<IClient>().Setup(x => x.SubaccountId).Returns(5);
+                Subject.Prepare(httpClient);
+                var match = httpClient.DefaultRequestHeaders.First(x => x.Key == "X-MSYS-SUBACCOUNT");
+                match.Value.Count().ShouldEqual(1);
+                match.Value.First().ShouldEqual("5");
+            }
+
+            [Test]
+            public void It_should_not_set_The_xmsys_subaccount_if_the_subaccount_is_zero()
+            {
+                Mocked<IClient>().Setup(x => x.SubaccountId).Returns(0);
+                Subject.Prepare(httpClient);
+                httpClient.DefaultRequestHeaders.Count(x => x.Key == "X-MSYS-SUBACCOUNT")
+                    .ShouldEqual(0);
+            }
+
+            [Test]
+            public void It_should_not_set_The_xmsys_subaccount_if_the_subaccount_is_less_than_zero()
+            {
+                Mocked<IClient>().Setup(x => x.SubaccountId).Returns(-1);
+                Subject.Prepare(httpClient);
+                httpClient.DefaultRequestHeaders.Count(x => x.Key == "X-MSYS-SUBACCOUNT")
+                    .ShouldEqual(0);
+            }
+        }
+    }
+}

--- a/src/SparkPost/Client.cs
+++ b/src/SparkPost/Client.cs
@@ -30,7 +30,18 @@ namespace SparkPost
             SubaccountId = subAccountId;
 
             var dataMapper = new DataMapper(Version);
-            var asyncRequestSender = new AsyncRequestSender(this, dataMapper, () => CustomSettings.CreateANewHttpClient());
+
+            Func<HttpClient> httpClientFactory = () =>
+            {
+                var httpClient = CustomSettings.CreateANewHttpClient();
+
+                var preparation = new HttpClientPreparation(this);
+                preparation.Prepare(httpClient);
+
+                return httpClient;
+            };
+
+            var asyncRequestSender = new AsyncRequestSender(this, dataMapper, httpClientFactory);
             var syncRequestSender = new SyncRequestSender(asyncRequestSender);
             var requestSender = new RequestSender(asyncRequestSender, syncRequestSender, this);
 

--- a/src/SparkPost/Client.cs
+++ b/src/SparkPost/Client.cs
@@ -50,20 +50,6 @@ namespace SparkPost
             CustomSettings = new Settings();
         }
 
-        private Func<HttpClient> TheWayToGetTheHttpClient()
-        {
-            return () =>
-            {
-                if (HttpClient != null) return HttpClient;
-
-                HttpClient = CustomSettings.CreateANewHttpClient();
-
-                new HttpClientPreparation(this).Prepare(HttpClient);
-
-                return HttpClient;
-            };
-        }
-
         public string ApiKey { get; set; }
         public string ApiHost { get; set; }
         public long SubaccountId { get; set; }
@@ -109,5 +95,23 @@ namespace SparkPost
             }
         }
 
+        private Func<HttpClient> TheWayToGetTheHttpClient()
+        {
+            return () =>
+            {
+                if (HttpClient != null) return HttpClient;
+
+                HttpClient = BuildANewHttpClient();
+
+                return HttpClient;
+            };
+        }
+
+        private HttpClient BuildANewHttpClient()
+        {
+            var httpClient = CustomSettings.CreateANewHttpClient();
+            new HttpClientPreparation(this).Prepare(httpClient);
+            return httpClient;
+        }
     }
 }

--- a/src/SparkPost/Client.cs
+++ b/src/SparkPost/Client.cs
@@ -30,7 +30,7 @@ namespace SparkPost
             SubaccountId = subAccountId;
 
             var dataMapper = new DataMapper(Version);
-            var asyncRequestSender = new AsyncRequestSender(this, dataMapper);
+            var asyncRequestSender = new AsyncRequestSender(this, dataMapper, () => CustomSettings.CreateANewHttpClient());
             var syncRequestSender = new SyncRequestSender(asyncRequestSender);
             var requestSender = new RequestSender(asyncRequestSender, syncRequestSender, this);
 

--- a/src/SparkPost/Client.cs
+++ b/src/SparkPost/Client.cs
@@ -32,7 +32,7 @@ namespace SparkPost
 
             var dataMapper = new DataMapper(Version);
 
-            Func<HttpClient> httpClientFactory = () =>
+            Func<HttpClient> httpClientRetriever = () =>
             {
                 if (httpClient != null) return httpClient;
 
@@ -44,7 +44,7 @@ namespace SparkPost
                 return httpClient;
             };
 
-            var asyncRequestSender = new AsyncRequestSender(this, dataMapper, httpClientFactory);
+            var asyncRequestSender = new AsyncRequestSender(this, dataMapper, httpClientRetriever);
             var syncRequestSender = new SyncRequestSender(asyncRequestSender);
             var requestSender = new RequestSender(asyncRequestSender, syncRequestSender, this);
 

--- a/src/SparkPost/Client.cs
+++ b/src/SparkPost/Client.cs
@@ -45,7 +45,7 @@ namespace SparkPost
                 return HttpClient;
             };
 
-            var asyncRequestSender = new AsyncRequestSender(this, dataMapper, httpClientRetriever);
+            var asyncRequestSender = new AsyncRequestSender(dataMapper, httpClientRetriever);
             var syncRequestSender = new SyncRequestSender(asyncRequestSender);
             var requestSender = new RequestSender(asyncRequestSender, syncRequestSender, this);
 

--- a/src/SparkPost/Client.cs
+++ b/src/SparkPost/Client.cs
@@ -33,19 +33,7 @@ namespace SparkPost
 
             var dataMapper = new DataMapper(Version);
 
-            Func<HttpClient> httpClientRetriever = () =>
-            {
-                if (HttpClient != null) return HttpClient;
-
-                HttpClient = CustomSettings.CreateANewHttpClient();
-
-                var preparation = new HttpClientPreparation(this);
-                preparation.Prepare(HttpClient);
-
-                return HttpClient;
-            };
-
-            var asyncRequestSender = new AsyncRequestSender(dataMapper, httpClientRetriever);
+            var asyncRequestSender = new AsyncRequestSender(dataMapper, TheWayToGetTheHttpClient());
             var syncRequestSender = new SyncRequestSender(asyncRequestSender);
             var requestSender = new RequestSender(asyncRequestSender, syncRequestSender, this);
 
@@ -60,6 +48,20 @@ namespace SparkPost
             RecipientLists = new RecipientLists(this, requestSender, dataMapper);
             Templates = new Templates(this, requestSender, dataMapper);
             CustomSettings = new Settings();
+        }
+
+        private Func<HttpClient> TheWayToGetTheHttpClient()
+        {
+            return () =>
+            {
+                if (HttpClient != null) return HttpClient;
+
+                HttpClient = CustomSettings.CreateANewHttpClient();
+
+                new HttpClientPreparation(this).Prepare(HttpClient);
+
+                return HttpClient;
+            };
         }
 
         public string ApiKey { get; set; }

--- a/src/SparkPost/Client.cs
+++ b/src/SparkPost/Client.cs
@@ -7,6 +7,7 @@ namespace SparkPost
     public class Client : IClient
     {
         private const string defaultApiHost = "https://api.sparkpost.com";
+        private HttpClient httpClient;
 
         public Client(string apiKey) : this(apiKey, defaultApiHost, 0)
         {
@@ -33,7 +34,9 @@ namespace SparkPost
 
             Func<HttpClient> httpClientFactory = () =>
             {
-                var httpClient = CustomSettings.CreateANewHttpClient();
+                if (httpClient != null) return httpClient;
+
+                httpClient = CustomSettings.CreateANewHttpClient();
 
                 var preparation = new HttpClientPreparation(this);
                 preparation.Prepare(httpClient);

--- a/src/SparkPost/Client.cs
+++ b/src/SparkPost/Client.cs
@@ -7,7 +7,8 @@ namespace SparkPost
     public class Client : IClient
     {
         private const string defaultApiHost = "https://api.sparkpost.com";
-        private HttpClient httpClient;
+
+        public HttpClient HttpClient { get; set; }
 
         public Client(string apiKey) : this(apiKey, defaultApiHost, 0)
         {
@@ -34,14 +35,14 @@ namespace SparkPost
 
             Func<HttpClient> httpClientRetriever = () =>
             {
-                if (httpClient != null) return httpClient;
+                if (HttpClient != null) return HttpClient;
 
-                httpClient = CustomSettings.CreateANewHttpClient();
+                HttpClient = CustomSettings.CreateANewHttpClient();
 
                 var preparation = new HttpClientPreparation(this);
-                preparation.Prepare(httpClient);
+                preparation.Prepare(HttpClient);
 
-                return httpClient;
+                return HttpClient;
             };
 
             var asyncRequestSender = new AsyncRequestSender(this, dataMapper, httpClientRetriever);

--- a/src/SparkPost/HttpClientPreparation.cs
+++ b/src/SparkPost/HttpClientPreparation.cs
@@ -18,7 +18,7 @@ namespace SparkPost
             httpClient.BaseAddress = new Uri(client.ApiHost);
             httpClient.DefaultRequestHeaders.Add("Authorization", client.ApiKey);
 
-            if (client.SubaccountId != 0)
+            if (client.SubaccountId > 0)
                 httpClient.DefaultRequestHeaders.Add("X-MSYS-SUBACCOUNT",
                     client.SubaccountId.ToString(CultureInfo.InvariantCulture));
         }

--- a/src/SparkPost/HttpClientPreparation.cs
+++ b/src/SparkPost/HttpClientPreparation.cs
@@ -1,0 +1,26 @@
+﻿using System;
+using System.Globalization;
+using System.Net.Http;
+
+namespace SparkPost
+{
+    public class HttpClientPreparation
+    {
+        private readonly IClient client;
+
+        public HttpClientPreparation(IClient client)
+        {
+            this.client = client;
+        }
+
+        public void Prepare(HttpClient httpClient)
+        {
+            httpClient.BaseAddress = new Uri(client.ApiHost);
+            httpClient.DefaultRequestHeaders.Add("Authorization", client.ApiKey);
+
+            if (client.SubaccountId != 0)
+                httpClient.DefaultRequestHeaders.Add("X-MSYS-SUBACCOUNT",
+                    client.SubaccountId.ToString(CultureInfo.InvariantCulture));
+        }
+    }
+}

--- a/src/SparkPost/RequestSenders/AsyncRequestSender.cs
+++ b/src/SparkPost/RequestSenders/AsyncRequestSender.cs
@@ -21,12 +21,7 @@ namespace SparkPost.RequestSenders
         public virtual async Task<Response> Send(Request request)
         {
                 var httpClient = httpClientFactory();
-                httpClient.BaseAddress = new Uri(client.ApiHost);
-                httpClient.DefaultRequestHeaders.Add("Authorization", client.ApiKey);
-
-                if (client.SubaccountId != 0)
-                    httpClient.DefaultRequestHeaders.Add("X-MSYS-SUBACCOUNT",
-                        client.SubaccountId.ToString(CultureInfo.InvariantCulture));
+                PrepareTheHttpClient(httpClient, client);
 
                 var result = await GetTheResponse(request, httpClient);
 
@@ -36,6 +31,16 @@ namespace SparkPost.RequestSenders
                     ReasonPhrase = result.ReasonPhrase,
                     Content = await result.Content.ReadAsStringAsync()
                 };
+        }
+
+        private static void PrepareTheHttpClient(HttpClient httpClient, IClient client)
+        {
+            httpClient.BaseAddress = new Uri(client.ApiHost);
+            httpClient.DefaultRequestHeaders.Add("Authorization", client.ApiKey);
+
+            if (client.SubaccountId != 0)
+                httpClient.DefaultRequestHeaders.Add("X-MSYS-SUBACCOUNT",
+                    client.SubaccountId.ToString(CultureInfo.InvariantCulture));
         }
 
         protected virtual async Task<HttpResponseMessage> GetTheResponse(Request request, HttpClient httpClient)

--- a/src/SparkPost/RequestSenders/AsyncRequestSender.cs
+++ b/src/SparkPost/RequestSenders/AsyncRequestSender.cs
@@ -27,8 +27,6 @@ namespace SparkPost.RequestSenders
                 if (client.SubaccountId != 0)
                     httpClient.DefaultRequestHeaders.Add("X-MSYS-SUBACCOUNT",
                         client.SubaccountId.ToString(CultureInfo.InvariantCulture));
-                else
-                    httpClient.DefaultRequestHeaders.Remove("X-MSYS-SUBACCOUNT");
 
                 var result = await GetTheResponse(request, httpClient);
 

--- a/src/SparkPost/RequestSenders/AsyncRequestSender.cs
+++ b/src/SparkPost/RequestSenders/AsyncRequestSender.cs
@@ -9,23 +9,26 @@ namespace SparkPost.RequestSenders
     {
         private readonly IClient client;
         private readonly IDataMapper dataMapper;
+        private readonly Func<HttpClient> httpClientFactory;
 
-        public AsyncRequestSender(IClient client, IDataMapper dataMapper)
+        public AsyncRequestSender(IClient client, IDataMapper dataMapper, Func<HttpClient> httpClientFactory)
         {
             this.client = client;
             this.dataMapper = dataMapper;
+            this.httpClientFactory = httpClientFactory;
         }
 
         public virtual async Task<Response> Send(Request request)
         {
-            using (var httpClient = client.CustomSettings.CreateANewHttpClient())
-            {
+                var httpClient = httpClientFactory();
                 httpClient.BaseAddress = new Uri(client.ApiHost);
                 httpClient.DefaultRequestHeaders.Add("Authorization", client.ApiKey);
 
                 if (client.SubaccountId != 0)
                     httpClient.DefaultRequestHeaders.Add("X-MSYS-SUBACCOUNT",
                         client.SubaccountId.ToString(CultureInfo.InvariantCulture));
+                else
+                    httpClient.DefaultRequestHeaders.Remove("X-MSYS-SUBACCOUNT");
 
                 var result = await GetTheResponse(request, httpClient);
 
@@ -35,7 +38,6 @@ namespace SparkPost.RequestSenders
                     ReasonPhrase = result.ReasonPhrase,
                     Content = await result.Content.ReadAsStringAsync()
                 };
-            }
         }
 
         protected virtual async Task<HttpResponseMessage> GetTheResponse(Request request, HttpClient httpClient)

--- a/src/SparkPost/RequestSenders/AsyncRequestSender.cs
+++ b/src/SparkPost/RequestSenders/AsyncRequestSender.cs
@@ -7,13 +7,11 @@ namespace SparkPost.RequestSenders
 {
     public class AsyncRequestSender : IRequestSender
     {
-        private readonly IClient client;
         private readonly IDataMapper dataMapper;
         private readonly Func<HttpClient> httpClientRetriever;
 
-        public AsyncRequestSender(IClient client, IDataMapper dataMapper, Func<HttpClient> httpClientRetriever)
+        public AsyncRequestSender(IDataMapper dataMapper, Func<HttpClient> httpClientRetriever)
         {
-            this.client = client;
             this.dataMapper = dataMapper;
             this.httpClientRetriever = httpClientRetriever;
         }

--- a/src/SparkPost/RequestSenders/AsyncRequestSender.cs
+++ b/src/SparkPost/RequestSenders/AsyncRequestSender.cs
@@ -18,16 +18,14 @@ namespace SparkPost.RequestSenders
 
         public virtual async Task<Response> Send(Request request)
         {
-                var httpClient = httpClientRetriever();
+            var result = await GetTheResponse(request, httpClientRetriever());
 
-                var result = await GetTheResponse(request, httpClient);
-
-                return new Response
-                {
-                    StatusCode = result.StatusCode,
-                    ReasonPhrase = result.ReasonPhrase,
-                    Content = await result.Content.ReadAsStringAsync()
-                };
+            return new Response
+            {
+                StatusCode = result.StatusCode,
+                ReasonPhrase = result.ReasonPhrase,
+                Content = await result.Content.ReadAsStringAsync()
+            };
         }
 
         protected virtual async Task<HttpResponseMessage> GetTheResponse(Request request, HttpClient httpClient)

--- a/src/SparkPost/RequestSenders/AsyncRequestSender.cs
+++ b/src/SparkPost/RequestSenders/AsyncRequestSender.cs
@@ -21,7 +21,8 @@ namespace SparkPost.RequestSenders
         public virtual async Task<Response> Send(Request request)
         {
                 var httpClient = httpClientFactory();
-                PrepareTheHttpClient(httpClient, client);
+                var preparation = new HttpClientPreparation(client);
+                preparation.Prepare(httpClient);
 
                 var result = await GetTheResponse(request, httpClient);
 
@@ -31,16 +32,6 @@ namespace SparkPost.RequestSenders
                     ReasonPhrase = result.ReasonPhrase,
                     Content = await result.Content.ReadAsStringAsync()
                 };
-        }
-
-        private static void PrepareTheHttpClient(HttpClient httpClient, IClient client)
-        {
-            httpClient.BaseAddress = new Uri(client.ApiHost);
-            httpClient.DefaultRequestHeaders.Add("Authorization", client.ApiKey);
-
-            if (client.SubaccountId != 0)
-                httpClient.DefaultRequestHeaders.Add("X-MSYS-SUBACCOUNT",
-                    client.SubaccountId.ToString(CultureInfo.InvariantCulture));
         }
 
         protected virtual async Task<HttpResponseMessage> GetTheResponse(Request request, HttpClient httpClient)

--- a/src/SparkPost/RequestSenders/AsyncRequestSender.cs
+++ b/src/SparkPost/RequestSenders/AsyncRequestSender.cs
@@ -21,8 +21,6 @@ namespace SparkPost.RequestSenders
         public virtual async Task<Response> Send(Request request)
         {
                 var httpClient = httpClientFactory();
-                var preparation = new HttpClientPreparation(client);
-                preparation.Prepare(httpClient);
 
                 var result = await GetTheResponse(request, httpClient);
 

--- a/src/SparkPost/RequestSenders/AsyncRequestSender.cs
+++ b/src/SparkPost/RequestSenders/AsyncRequestSender.cs
@@ -9,18 +9,18 @@ namespace SparkPost.RequestSenders
     {
         private readonly IClient client;
         private readonly IDataMapper dataMapper;
-        private readonly Func<HttpClient> httpClientFactory;
+        private readonly Func<HttpClient> httpClientRetriever;
 
-        public AsyncRequestSender(IClient client, IDataMapper dataMapper, Func<HttpClient> httpClientFactory)
+        public AsyncRequestSender(IClient client, IDataMapper dataMapper, Func<HttpClient> httpClientRetriever)
         {
             this.client = client;
             this.dataMapper = dataMapper;
-            this.httpClientFactory = httpClientFactory;
+            this.httpClientRetriever = httpClientRetriever;
         }
 
         public virtual async Task<Response> Send(Request request)
         {
-                var httpClient = httpClientFactory();
+                var httpClient = httpClientRetriever();
 
                 var result = await GetTheResponse(request, httpClient);
 

--- a/src/SparkPost/SparkPost.csproj
+++ b/src/SparkPost/SparkPost.csproj
@@ -62,6 +62,7 @@
     <Compile Include="Dkim.cs" />
     <Compile Include="Dns.cs" />
     <Compile Include="GetSendingDomainResponse.cs" />
+    <Compile Include="HttpClientPreparation.cs" />
     <Compile Include="IMessageEvents.cs" />
     <Compile Include="IRecipientLists.cs" />
     <Compile Include="ISendingDomains.cs" />


### PR DESCRIPTION
Based on information read from http://www.westerndevs.com/Deployment/httpclientwrong/, from @crmckenzie, I'm going to change the way that this library uses HttpClient.  Instead of creating a new HttpClient every time a web request is made, I am going to register a single instance of it and use it for all subsequent requests.

It will still be up to the user of this library to register a single instance of `IClient`.  But this will, at least, allow users to get around this potential issue if web requests are made in higher volume.
