### PR TITLE
Add factory methods for File

### DIFF
--- a/src/SparkPost.Tests/FileTests.cs
+++ b/src/SparkPost.Tests/FileTests.cs
@@ -1,0 +1,53 @@
+﻿using NUnit.Framework;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace SparkPost.Tests
+{
+    [TestFixture]
+    public class FileTests
+    {
+        [Test]
+        public void It_should_create_correct_type()
+        {
+            byte[] content = null;
+            Assert.That(File.Create<Attachment>(content), Is.InstanceOf<Attachment>());
+            Assert.That(File.Create<InlineImage>(content), Is.InstanceOf<InlineImage>());
+        }
+
+        [TestCase("This is some test data.")]
+        [TestCase("This is some other data.")]
+        public void It_should_encode_data_correctly(string s)
+        {
+            var b = GetBytes(s);
+            var attach = File.Create<Attachment>(b);
+            Assert.That(attach.Data, Is.EqualTo(EncodeString(s)));
+        }
+
+        [TestCase("foo.png", "image/png")]
+        [TestCase("foo.txt", "text/plain")]
+        [TestCase("sf", "application/octet-stream")]
+        [TestCase("", "application/octet-stream")]
+        public void It_should_set_name_and_type_correctly(string filename, string mimeType)
+        {
+            var b = GetBytes("Some Test Data");
+            var attach = File.Create<Attachment>(b, filename);
+            Assert.That(attach.Name, Is.EqualTo(filename));
+            Assert.That(attach.Type, Is.EqualTo(mimeType));
+        }
+
+        private byte[] GetBytes(string input)
+        {
+            return Encoding.ASCII.GetBytes(input);
+        }
+
+        private string EncodeString(string input)
+        {
+            return Convert.ToBase64String(GetBytes(input));
+        }
+
+    }
+}

--- a/src/SparkPost.Tests/SparkPost.Tests.csproj
+++ b/src/SparkPost.Tests/SparkPost.Tests.csproj
@@ -87,6 +87,7 @@
   <ItemGroup>
     <Compile Include="ClientTests.cs" />
     <Compile Include="DataMapperTests.cs" />
+    <Compile Include="FileTests.cs" />
     <Compile Include="ListMessageEventsResponseTests.cs" />
     <Compile Include="MessageEventsQueryTests.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />

--- a/src/SparkPost/File.cs
+++ b/src/SparkPost/File.cs
@@ -1,9 +1,57 @@
-﻿namespace SparkPost
+﻿using System;
+using System.IO;
+using System.Web;
+
+namespace SparkPost
 {
     public abstract class File
     {
         public string Type { get; set; }
         public string Name { get; set; }
         public string Data { get; set; }
+
+        public static T Create<T>(string filename) where T : File, new()
+        {
+            var content = System.IO.File.ReadAllBytes(filename);
+            return Create<T>(content, Path.GetFileName(filename));            
+        }
+
+        public static T Create<T>(string filename, string name) where T : SparkPost.File, new()
+        {
+            var result = Create<T>(filename);
+            result.Name = name;
+            return result;
+        }
+
+        public static T Create<T>(byte[] content) where T : File, new()
+        {
+            return Create<T>(content, String.Empty);
+        }
+
+        public static T Create<T>(byte[] content, string name) where T : File, new()
+        {
+            var result = new T();
+            if (content != null)
+            {
+                result.Data = Convert.ToBase64String(content);
+                result.Type = MimeMapping.GetMimeMapping(name);
+                result.Name = name;
+            };
+            return result;
+        }
+
+        public static T Create<T>(Stream content) where T : File, new()
+        {
+            return Create<T>(content, String.Empty);
+        }
+
+        public static T Create<T>(Stream content, string name) where T : File, new()
+        {
+            using (var ms = new MemoryStream())
+            {
+                content.CopyTo(ms);
+                return Create<T>(ms.ToArray(), name);
+            }
+        }
     }
 }

--- a/src/SparkPost/File.cs
+++ b/src/SparkPost/File.cs
@@ -16,7 +16,7 @@ namespace SparkPost
             return Create<T>(content, Path.GetFileName(filename));            
         }
 
-        public static T Create<T>(string filename, string name) where T : SparkPost.File, new()
+        public static T Create<T>(string filename, string name) where T : File, new()
         {
             var result = Create<T>(filename);
             result.Name = name;


### PR DESCRIPTION
I've added some `File.Create<T>()` factory methods for more easily creating attachments and inline images from files, byte arrays, and streams.