### PR TITLE
Ability to work with MailMessage

### DIFF
--- a/src/SparkPost.Tests/TransmissionTests.cs
+++ b/src/SparkPost.Tests/TransmissionTests.cs
@@ -5,6 +5,10 @@ using System.Runtime.CompilerServices;
 using Moq;
 using NUnit.Framework;
 using Should;
+using System.Net.Mail;
+using System.Net.Mime;
+using System.IO;
+using System.Text;
 
 namespace SparkPost.Tests
 {
@@ -43,6 +47,154 @@ namespace SparkPost.Tests
             public void It_should_not_be_missing_substition_data()
             {
                 transmission.SubstitutionData.ShouldNotBeNull();
+            }
+        }
+
+        [TestFixture]
+        public class ParseTests
+        {
+            private MailMessage _msg;
+            private Transmission _trans;
+
+            [SetUp]
+            public void Setup()
+            {
+                _msg = new MailMessage();
+                _msg.From = new MailAddress("jim@example.com", "Jim Example");
+                _msg.To.Add(new MailAddress("bob@example.com", "Bob Example"));
+                _msg.CC.Add(new MailAddress("susan@example.com", "Susan Example"));
+                _msg.Bcc.Add(new MailAddress("richard@example.com", "Richard Example"));
+                _msg.ReplyToList.Add(new MailAddress("rebecca@example.com", "Rebecca Example"));
+                _msg.Body = "Unit test message";
+                _msg.Subject = "Test ssubject";
+
+
+
+                _trans = new Transmission(_msg);                
+            }
+
+            
+            [Test]
+            public void From_should_match()
+            {
+                Assert.That(_trans.Content.From.Name, Is.EqualTo(_msg.From.DisplayName));
+                Assert.That(_trans.Content.From.Email, Is.EqualTo(_msg.From.Address));
+            }
+
+            [Test]
+            public void It_should_have_three_recipients()
+            {
+                Assert.That(_trans.Recipients.Count, Is.EqualTo(3));
+            }
+
+            [Test]
+            public void To_should_match()
+            {
+                var to = _trans.Recipients.SingleOrDefault(r => r.Type == RecipientType.To);
+                Assert.That(to, Is.Not.Null);
+                Assert.That(to.Address.Name == _msg.To.First().DisplayName);
+                Assert.That(to.Address.Email == _msg.To.First().Address);
+            }
+
+            [Test]
+            public void Cc_should_match()
+            {
+                var cc = _trans.Recipients.SingleOrDefault(r => r.Type == RecipientType.CC);
+                Assert.That(cc, Is.Not.Null);
+                Assert.That(cc.Address.Name == _msg.CC.First().DisplayName);
+                Assert.That(cc.Address.Email == _msg.CC.First().Address);
+            }
+
+            [Test]
+            public void Bcc_should_match()
+            {
+                var bcc = _trans.Recipients.SingleOrDefault(r => r.Type == RecipientType.BCC);
+                Assert.That(bcc, Is.Not.Null);
+                Assert.That(bcc.Address.Name == _msg.Bcc.First().DisplayName);
+                Assert.That(bcc.Address.Email == _msg.Bcc.First().Address);
+            }
+
+            [Test]
+            public void Replyto_should_match()
+            {
+                Assert.That(_trans.Content.ReplyTo, Is.EqualTo(_msg.ReplyToList.First().Address));
+            }
+
+            [Test]
+            public void Subject_should_match()
+            {
+                Assert.That(_trans.Content.Subject, Is.EqualTo(_msg.Subject));
+            }
+
+            [Test]
+            public void Text_body_should_match()
+            {
+                Assert.That(_trans.Content.Text, Is.EqualTo(_msg.Body));
+            }
+
+            [Test]
+            public void Html_body_should_match()
+            {
+                _msg.IsBodyHtml = true;
+                _trans = new Transmission(_msg);
+                Assert.That(_trans.Content.Html, Is.EqualTo(_msg.Body));
+            }
+
+            [Test]
+            public void It_should_use_alternate_html_view()
+            {
+                var html = "<p>Html body</p>";
+                var view = AlternateView.CreateAlternateViewFromString(html, null, MediaTypeNames.Text.Html);
+                _msg.AlternateViews.Add(view);
+                _trans = new Transmission(_msg);
+
+                Assert.That(_trans.Content.Html, Is.EqualTo(html));
+            }
+
+            [Test]
+            public void It_should_use_alternate_text_view()
+            {
+                _msg.IsBodyHtml = true;
+                var text = "Text body";
+                var view = AlternateView.CreateAlternateViewFromString(text, null, MediaTypeNames.Text.Plain);
+                _msg.AlternateViews.Add(view);
+                _trans = new Transmission(_msg);
+
+                Assert.That(_trans.Content.Text, Is.EqualTo(text));
+            }
+
+            [Test]
+            public void It_should_use_both_alternate_views()
+            {
+                var text = "Alternate text";
+                var html = "Alternate html";
+                var view = AlternateView.CreateAlternateViewFromString(text, null, MediaTypeNames.Text.Plain);
+                _msg.AlternateViews.Add(view);
+                view = AlternateView.CreateAlternateViewFromString(html, null, MediaTypeNames.Text.Html);
+                _msg.AlternateViews.Add(view);
+                _trans = new Transmission(_msg);
+
+                Assert.That(_trans.Content.Text, Is.EqualTo(text));
+                Assert.That(_trans.Content.Html, Is.EqualTo(html));
+            }
+
+            [Test]
+            public void It_should_copy_attachments()
+            {
+                var text = "This is an attachment";
+                var name = "foo.txt";
+                var type = "text/plain";
+                var ms = new MemoryStream(Encoding.ASCII.GetBytes(text));
+                _msg.Attachments.Add(new System.Net.Mail.Attachment(ms, name, type));
+                _trans = new Transmission(_msg);
+
+                Assert.That(_trans.Content.Attachments.Count, Is.EqualTo(1));
+                Assert.That(_trans.Content.Attachments.First().Type, Is.EqualTo(type));
+                Assert.That(_trans.Content.Attachments.First().Name, Is.EqualTo(name));
+
+                var bytes = Convert.FromBase64String(_trans.Content.Attachments.First().Data);
+                var decoded = Encoding.ASCII.GetString(bytes);
+                Assert.That(decoded, Is.EqualTo(text));
             }
         }
     }

--- a/src/SparkPost/Address.cs
+++ b/src/SparkPost/Address.cs
@@ -5,5 +5,24 @@
         public string Name { get; set; }
         public string Email { get; set; }
         public string HeaderTo { get; set; }
+
+        public Address()
+        {
+        }
+
+        public Address(string email): this(email, null, null)
+        {
+        }
+
+        public Address(string email, string name): this(email, name, null)
+        {
+        }
+
+        public Address(string email, string name, string headerTo)
+        {
+            this.Email = email;
+            this.Name = name;
+            this.HeaderTo = headerTo;
+        }
     }
 }

--- a/src/SparkPost/Transmission.cs
+++ b/src/SparkPost/Transmission.cs
@@ -62,11 +62,16 @@ namespace SparkPost
 
             var textTypes = new[] { MediaTypeNames.Text.Plain, MediaTypeNames.Text.Html };
             var views = message.AlternateViews;
-            if (views.Count < 2 &&
+            if (views.Any() && views.Count <= 2 &&
                 !views.Select(av => av.ContentType.MediaType).Except(textTypes).Any())
             {
-                Content.Text = GetViewContent(views, MediaTypeNames.Text.Plain);
-                Content.Html = GetViewContent(views, MediaTypeNames.Text.Html);
+                var text = GetViewContent(views, MediaTypeNames.Text.Plain);
+                if (text != null)
+                    Content.Text = text;
+
+                var html = GetViewContent(views, MediaTypeNames.Text.Html);
+                if (html != null)
+                    Content.Html = html;
             }
             
             foreach (var attach in message.Attachments)

--- a/src/SparkPost/Transmission.cs
+++ b/src/SparkPost/Transmission.cs
@@ -1,4 +1,9 @@
 ﻿using System.Collections.Generic;
+using System.Net.Mail;
+using System.Net.Mime;
+using System.Linq;
+using System;
+using System.IO;
 
 namespace SparkPost
 {
@@ -10,7 +15,12 @@ namespace SparkPost
             Metadata = new Dictionary<string, object>();
             SubstitutionData = new Dictionary<string, object>();
             Content = new Content();
-            Options = new Options();
+            Options = new Options();            
+        }
+
+        public Transmission(MailMessage message): this()
+        {
+            Parse(message);
         }
 
         public string Id { get; set; }
@@ -30,5 +40,69 @@ namespace SparkPost
         public int NumGenerated { get; set; }
         public int NumFailedGeneration { get; set; }
         public int NumInvalidRecipients { get; set; }
+
+        public void Parse(MailMessage message)
+        {
+            Content.From = new Address(message.From.Address, message.From.DisplayName);
+            Content.Subject = message.Subject;
+
+            AddRecipients(message.To, RecipientType.To);
+            AddRecipients(message.CC, RecipientType.CC);
+            AddRecipients(message.Bcc, RecipientType.BCC);
+
+            if (message.ReplyToList.Any())
+            {
+                Content.ReplyTo = message.ReplyToList.First().Address;
+            }
+
+            if (message.IsBodyHtml)
+                Content.Html = message.Body;
+            else
+                Content.Text = message.Body;
+
+            var textTypes = new[] { MediaTypeNames.Text.Plain, MediaTypeNames.Text.Html };
+            var views = message.AlternateViews;
+            if (views.Count < 2 &&
+                !views.Select(av => av.ContentType.MediaType).Except(textTypes).Any())
+            {
+                Content.Text = GetViewContent(views, MediaTypeNames.Text.Plain);
+                Content.Html = GetViewContent(views, MediaTypeNames.Text.Html);
+            }
+            
+            foreach (var attach in message.Attachments)
+            {
+                var newAttach = File.Create<Attachment>(attach.ContentStream, attach.ContentType.Name);
+                Content.Attachments.Add(newAttach);
+            }
+        }
+
+        private string GetViewContent(AlternateViewCollection views, string type)
+        {
+            string result = null;
+
+            var view = views.FirstOrDefault(v => v.ContentType.MediaType == type);
+            if (view != null)
+            { 
+                var rdr = new StreamReader(view.ContentStream);
+                if (view.ContentStream.CanSeek)
+                    view.ContentStream.Position = 0;
+                result = rdr.ReadToEnd();
+            }
+
+            return result;
+        }
+
+        private void AddRecipients(MailAddressCollection addrs, RecipientType type)
+        {
+            foreach (var addr in addrs)
+            {
+                var recp = new Recipient()
+                {
+                    Type = type,
+                    Address = new Address(addr.Address, addr.DisplayName)
+                };
+                Recipients.Add(recp);
+            }
+        }
     }
 }


### PR DESCRIPTION
Hi Darren,

Since users may already have existing code that creates a `MailMessage` and sends via SMTP, I thought it would be useful to be able to create a `Transmission` from that. So I've addded:
```csharp
public Transmission(MailMessage message): this()
{
   Parse(message);
}

public void Parse(MailMessage message)
{
   ...
}
```
`Parse` will pull in all the address fields, text and html bodies, subject, and attachments. 

I also dropped in some alternate constructors for `Address` to make them a little cleaner, on the analogy of `MailAddress`.