### PR TITLE
Static helper for the construction of a transmission from a mail message

### DIFF
--- a/src/SparkPost.Tests/TransmissionTests.cs
+++ b/src/SparkPost.Tests/TransmissionTests.cs
@@ -68,7 +68,7 @@ namespace SparkPost.Tests
                 mailMessage.Body = "Unit test message";
                 mailMessage.Subject = "Test ssubject";
 
-                transmission = new Transmission(mailMessage);
+                transmission = Transmission.Parse(mailMessage);
             }
 
             [Test]
@@ -133,7 +133,7 @@ namespace SparkPost.Tests
             public void Html_body_should_match()
             {
                 mailMessage.IsBodyHtml = true;
-                transmission = new Transmission(mailMessage);
+                transmission = Transmission.Parse(mailMessage);
                 Assert.That(transmission.Content.Html, Is.EqualTo(mailMessage.Body));
             }
 
@@ -143,7 +143,7 @@ namespace SparkPost.Tests
                 var html = "<p>Html body</p>";
                 var view = AlternateView.CreateAlternateViewFromString(html, null, MediaTypeNames.Text.Html);
                 mailMessage.AlternateViews.Add(view);
-                transmission = new Transmission(mailMessage);
+                transmission = Transmission.Parse(mailMessage);
 
                 Assert.That(transmission.Content.Html, Is.EqualTo(html));
             }
@@ -155,7 +155,7 @@ namespace SparkPost.Tests
                 var text = "Text body";
                 var view = AlternateView.CreateAlternateViewFromString(text, null, MediaTypeNames.Text.Plain);
                 mailMessage.AlternateViews.Add(view);
-                transmission = new Transmission(mailMessage);
+                transmission = Transmission.Parse(mailMessage);
 
                 Assert.That(transmission.Content.Text, Is.EqualTo(text));
             }
@@ -169,7 +169,7 @@ namespace SparkPost.Tests
                 mailMessage.AlternateViews.Add(view);
                 view = AlternateView.CreateAlternateViewFromString(html, null, MediaTypeNames.Text.Html);
                 mailMessage.AlternateViews.Add(view);
-                transmission = new Transmission(mailMessage);
+                transmission = Transmission.Parse(mailMessage);
 
                 Assert.That(transmission.Content.Text, Is.EqualTo(text));
                 Assert.That(transmission.Content.Html, Is.EqualTo(html));
@@ -183,7 +183,7 @@ namespace SparkPost.Tests
                 var type = "text/plain";
                 var ms = new MemoryStream(Encoding.ASCII.GetBytes(text));
                 mailMessage.Attachments.Add(new System.Net.Mail.Attachment(ms, name, type));
-                transmission = new Transmission(mailMessage);
+                transmission = Transmission.Parse(mailMessage);
 
                 Assert.That(transmission.Content.Attachments.Count, Is.EqualTo(1));
                 Assert.That(transmission.Content.Attachments.First().Type, Is.EqualTo(type));

--- a/src/SparkPost/Transmission.cs
+++ b/src/SparkPost/Transmission.cs
@@ -15,11 +15,6 @@ namespace SparkPost
             Options = new Options();
         }
 
-        public Transmission(MailMessage message) : this()
-        {
-            MailMessageMapping.ToTransmission(message, this);
-        }
-
         public string Id { get; set; }
         public string State { get; set; }
         public Options Options { get; set; }
@@ -37,6 +32,13 @@ namespace SparkPost
         public int NumGenerated { get; set; }
         public int NumFailedGeneration { get; set; }
         public int NumInvalidRecipients { get; set; }
+
+        public static Transmission Parse(MailMessage message)
+        {
+            var transmission = new Transmission();
+            MailMessageMapping.ToTransmission(message, transmission);
+            return transmission;
+        }
 
         public void LoadFrom(MailMessage message)
         {

--- a/src/SparkPost/Transmission.cs
+++ b/src/SparkPost/Transmission.cs
@@ -35,9 +35,7 @@ namespace SparkPost
 
         public static Transmission Parse(MailMessage message)
         {
-            var transmission = new Transmission();
-            MailMessageMapping.ToTransmission(message, transmission);
-            return transmission;
+            return MailMessageMapping.ToTransmission(message);
         }
 
         public void LoadFrom(MailMessage message)


### PR DESCRIPTION
As discussed on #124.

I think it would be better to keep the ```Transmission``` class as isolated from ```MailMessage``` as possible, and I don't want to create confusion from people who think that they must or should use a ```MailMessage``` to create a ```Transmission```.  

So this pull request just removes the constructor that takes a mail message, and replaces it with a static helper.  

Since ```MailMessage``` is in the .Net framework, I think it's ok to have the static helpers in the POCO object's class.  