### PR TITLE
Try replacing the async request handler with one that works in mono

### DIFF
--- a/src/SparkPost/RequestSenders/MonoRequestSender.cs
+++ b/src/SparkPost/RequestSenders/MonoRequestSender.cs
@@ -1,0 +1,48 @@
+﻿using System;
+using System.Globalization;
+using System.Net.Http;
+using System.Threading.Tasks;
+
+namespace SparkPost.RequestSenders
+{
+    public class MonoRequestSender : IRequestSender
+    {
+        private readonly IClient client;
+        private readonly IDataMapper dataMapper;
+
+        public MonoRequestSender(IClient client, IDataMapper dataMapper)
+        {
+            this.client = client;
+            this.dataMapper = dataMapper;
+        }
+
+        public virtual async Task<Response> Send(Request request)
+        {
+            using (var httpClient = client.CustomSettings.CreateANewHttpClient())
+            {
+                httpClient.BaseAddress = new Uri(client.ApiHost);
+                httpClient.DefaultRequestHeaders.Add("Authorization", client.ApiKey);
+
+                if (client.SubaccountId != 0)
+                    httpClient.DefaultRequestHeaders.Add("X-MSYS-SUBACCOUNT",
+                        client.SubaccountId.ToString(CultureInfo.InvariantCulture));
+
+                var result = await GetTheResponse(request, httpClient);
+
+                return new Response
+                {
+                    StatusCode = result.StatusCode,
+                    ReasonPhrase = result.ReasonPhrase,
+                    Content = await result.Content.ReadAsStringAsync()
+                };
+            }
+        }
+
+        protected virtual async Task<HttpResponseMessage> GetTheResponse(Request request, HttpClient httpClient)
+        {
+            return await new RequestMethodFinder(httpClient, dataMapper)
+                .FindFor(request)
+                .Execute(request);
+        }
+    }
+}

--- a/src/SparkPost/SparkPost.csproj
+++ b/src/SparkPost/SparkPost.csproj
@@ -84,6 +84,7 @@
     <Compile Include="PageLink.cs" />
     <Compile Include="RecipientList.cs" />
     <Compile Include="RecipientLists.cs" />
+    <Compile Include="RequestSenders\MonoRequestSender.cs" />
     <Compile Include="RetrieveRecipientListsResponse.cs" />
     <Compile Include="RetrieveRelayWebhookResponse.cs" />
     <Compile Include="InboundDomainResponse.cs" />


### PR DESCRIPTION
This is a gasping attempt to resolve #111.

Notes... it seems that setting the headers with the ```HttpClient``` does not work with Mono?  Notes:

https://bugzilla.xamarin.com/show_bug.cgi?id=41133#c41

http://stackoverflow.com/questions/17187347/webheadercollection-httpwebrequest-on-xamarin#17267044

My thought is to try what they're doing... see if I can switch to using ```HttpWebRequest ``` ??