### PR TITLE
Cc handling

### DIFF
--- a/src/SparkPost.Tests/DataMapperTests.cs
+++ b/src/SparkPost.Tests/DataMapperTests.cs
@@ -340,7 +340,7 @@ namespace SparkPost.Tests
                     .CastAs<IDictionary<string, string>>()
                     ["CC"];
 
-                cc.ShouldEqual("<" + recipient1.Address.Email + ">,<" + recipient3.Address.Email + ">");
+                cc.ShouldEqual(recipient1.Address.Email + ", " + recipient3.Address.Email);
             }
 
             [Test]
@@ -350,7 +350,8 @@ namespace SparkPost.Tests
                 var value = Guid.NewGuid().ToString();
 
                 var recipient1 = new Recipient {Type = RecipientType.CC, Address = new Address {Email = Guid.NewGuid().ToString()}};
-                transmission.Recipients = new List<Recipient> {recipient1};
+                var toRecipient = new Recipient { Type = RecipientType.To, Address = new Address() };
+                transmission.Recipients = new List<Recipient> {recipient1, toRecipient};
 
                 transmission.Content.Headers[key] = value;
 
@@ -403,7 +404,8 @@ namespace SparkPost.Tests
                 var recipient1 = new Recipient {Type = RecipientType.CC, Address = new Address {Email = ""}};
                 var recipient2 = new Recipient {Type = RecipientType.CC, Address = new Address {Email = null}};
                 var recipient3 = new Recipient {Type = RecipientType.CC, Address = new Address {Email = " "}};
-                transmission.Recipients = new List<Recipient> {recipient1, recipient2, recipient3};
+                var toRecipient = new Recipient { Type = RecipientType.To, Address = new Address() };
+                transmission.Recipients = new List<Recipient> {recipient1, recipient2, recipient3, toRecipient};
 
                  mapper.ToDictionary(transmission)
                     ["content"]
@@ -416,7 +418,8 @@ namespace SparkPost.Tests
             public void It_should_ignore_any_cc_recipients_with_no_address()
             {
                 var recipient1 = new Recipient {Type = RecipientType.CC, Address = null};
-                transmission.Recipients = new List<Recipient> {recipient1};
+                var toRecipient = new Recipient { Type = RecipientType.To, Address = new Address() };
+                transmission.Recipients = new List<Recipient> {recipient1, toRecipient};
 
                  mapper.ToDictionary(transmission)
                     ["content"]

--- a/src/SparkPost.Tests/DataMapperTests.cs
+++ b/src/SparkPost.Tests/DataMapperTests.cs
@@ -324,13 +324,16 @@ namespace SparkPost.Tests
             private Transmission transmission;
             private DataMapper mapper;
 
-            [Test]
-            public void It_should_set_the_CC_Header_for_only_the_cc_emails()
+            [TestCase(true)]
+            [TestCase(false)]
+            public void It_should_set_the_CC_Header_for_only_the_cc_emails(bool useTo)
             {
                 var recipient1 = new Recipient {Type = RecipientType.CC, Address = new Address {Email = Guid.NewGuid().ToString()}};
-                var recipient2 = new Recipient {Type = RecipientType.To, Address = new Address {Email = Guid.NewGuid().ToString()}};
+                var recipient2 = new Recipient {Type = RecipientType.BCC, Address = new Address { Email = Guid.NewGuid().ToString()}};
                 var recipient3 = new Recipient {Type = RecipientType.CC, Address = new Address {Email = Guid.NewGuid().ToString()}};
-                var recipient4 = new Recipient {Type = RecipientType.BCC, Address = new Address { Email = Guid.NewGuid().ToString()}};
+                var recipient4 = useTo 
+                        ? new Recipient { Type = RecipientType.To, Address = new Address { Email = Guid.NewGuid().ToString() } }
+                        : new Recipient();
 
                 transmission.Recipients = new List<Recipient> {recipient1, recipient2, recipient3, recipient4};
 
@@ -344,15 +347,18 @@ namespace SparkPost.Tests
                 cc.ShouldEqual(recipient1.Address.Email + ", " + recipient3.Address.Email);
             }
             
-            [Test]
-            public void It_should_not_overwrite_any_existing_headers()
+            [TestCase(true)]
+            [TestCase(false)]
+            public void It_should_not_overwrite_any_existing_headers(bool useTo)
             {
                 var key = Guid.NewGuid().ToString();
                 var value = Guid.NewGuid().ToString();
 
                 var recipient1 = new Recipient {Type = RecipientType.CC, Address = new Address {Email = Guid.NewGuid().ToString()}};
-                var toRecipient = new Recipient { Type = RecipientType.To, Address = new Address() };
-                transmission.Recipients = new List<Recipient> {recipient1, toRecipient};
+                var recipient2 = useTo
+                        ? new Recipient { Type = RecipientType.To, Address = new Address() }
+                        : new Recipient();
+                transmission.Recipients = new List<Recipient> {recipient1, recipient2};
 
                 transmission.Content.Headers[key] = value;
 
@@ -364,15 +370,19 @@ namespace SparkPost.Tests
                     [key].ShouldEqual(value);
             }
 
-            [Test]
-            public void It_should_not_set_the_cc_if_there_are_no_cc_emails()
+            [TestCase(true)]
+            [TestCase(false)]
+            public void It_should_not_set_the_cc_if_there_are_no_cc_emails(bool useTo)
             {
                 var key = Guid.NewGuid().ToString();
                 var value = Guid.NewGuid().ToString();
 
-                var recipient1 = new Recipient {Type = RecipientType.To, Address = new Address {Email = Guid.NewGuid().ToString()}};
+                var recipient1 = useTo
+                        ? new Recipient { Type = RecipientType.To, Address = new Address { Email = Guid.NewGuid().ToString() } }
+                        : new Recipient();
                 var recipient2 = new Recipient {Type = RecipientType.BCC, Address = new Address {Email = Guid.NewGuid().ToString()}};
-                transmission.Recipients = new List<Recipient> {recipient1, recipient2};
+                var recipient3 = new Recipient { Type = RecipientType.BCC, Address = new Address { Email = Guid.NewGuid().ToString() } };
+                transmission.Recipients = new List<Recipient> {recipient1, recipient2, recipient3};
 
                 transmission.Content.Headers[key] = value;
 
@@ -385,10 +395,13 @@ namespace SparkPost.Tests
                     .ShouldBeFalse();
             }
 
-            [Test]
-            public void It_should_not_set_a_header_value_if_there_are_no_ccs()
+            [TestCase(true)]
+            [TestCase(false)]
+            public void It_should_not_set_a_header_value_if_there_are_no_ccs(bool useTo)
             {
-                var recipient1 = new Recipient {Type = RecipientType.To, Address = new Address {Email = Guid.NewGuid().ToString()}};
+                var recipient1 = useTo
+                        ? new Recipient { Type = RecipientType.To, Address = new Address { Email = Guid.NewGuid().ToString() } }
+                        : new Recipient();
                 var recipient2 = new Recipient {Type = RecipientType.BCC, Address = new Address {Email = Guid.NewGuid().ToString()}};
                 transmission.Recipients = new List<Recipient> {recipient1, recipient2};
 
@@ -399,13 +412,16 @@ namespace SparkPost.Tests
                     .ShouldBeFalse();
             }
 
-            [Test]
-            public void It_should_ignore_empty_ccs()
+            [TestCase(true)]
+            [TestCase(false)]
+            public void It_should_ignore_empty_ccs(bool useTo)
             {
                 var recipient1 = new Recipient {Type = RecipientType.CC, Address = new Address {Email = ""}};
                 var recipient2 = new Recipient {Type = RecipientType.CC, Address = new Address {Email = null}};
                 var recipient3 = new Recipient {Type = RecipientType.CC, Address = new Address {Email = " "}};
-                var toRecipient = new Recipient { Type = RecipientType.To, Address = new Address() };
+                var toRecipient = useTo
+                        ? new Recipient { Type = RecipientType.To, Address = new Address() }
+                        : new Recipient();
                 transmission.Recipients = new List<Recipient> {recipient1, recipient2, recipient3, toRecipient};
 
                  mapper.ToDictionary(transmission)
@@ -415,11 +431,14 @@ namespace SparkPost.Tests
                     .ShouldBeFalse();
             }
 
-            [Test]
-            public void It_should_ignore_any_cc_recipients_with_no_address()
+            [TestCase(true)]
+            [TestCase(false)]
+            public void It_should_ignore_any_cc_recipients_with_no_address(bool useTo)
             {
                 var recipient1 = new Recipient {Type = RecipientType.CC, Address = null};
-                var toRecipient = new Recipient { Type = RecipientType.To, Address = new Address() };
+                var toRecipient = useTo
+                        ? new Recipient { Type = RecipientType.To, Address = new Address() }
+                        : new Recipient();
                 transmission.Recipients = new List<Recipient> {recipient1, toRecipient};
 
                  mapper.ToDictionary(transmission)
@@ -453,37 +472,6 @@ namespace SparkPost.Tests
                 }
             }
 
-            [Test]
-            public void It_should_throw_exception_with_no_to_recipient()
-            {
-                var recipient1 = new Recipient { Type = RecipientType.CC, Address = new Address() };
-                var recipient2 = new Recipient { Type = RecipientType.BCC, Address = new Address() };
-                transmission.Recipients = new List<Recipient> { recipient1, recipient2 };
-
-                Assert.That(() => { mapper.ToDictionary(transmission); }, Throws.ArgumentException);
-            }
-
-            [Test]
-            public void It_should_throw_exception_with_multiple_to_recipients()
-            {
-                var recipient1 = new Recipient { Type = RecipientType.To, Address = new Address() };
-                var recipient2 = new Recipient { Type = RecipientType.To, Address = new Address() };
-                var recipient3 = new Recipient { Type = RecipientType.CC, Address = new Address() };
-                transmission.Recipients = new List<Recipient> { recipient1, recipient2, recipient3 };
-
-                Assert.That(() => { mapper.ToDictionary(transmission); }, Throws.ArgumentException);
-            }
-
-            [Test]
-            public void It_should_throw_exception_if_to_has_no_address()
-            {
-                var recipient1 = new Recipient { Type = RecipientType.To, Address = null };
-                var recipient2 = new Recipient { Type = RecipientType.BCC, Address = new Address() };
-                transmission.Recipients = new List<Recipient> { recipient1, recipient2 };
-
-                Assert.That(() => { mapper.ToDictionary(transmission); }, Throws.ArgumentException);
-            }
-
             [TestCase("Bob Jones", "bob@jones.com", "Bob Jones <bob@jones.com>")]
             [TestCase(null, "bob@jones.com", "bob@jones.com")]
             [TestCase("", "bob@jones.com", "bob@jones.com")]
@@ -501,6 +489,49 @@ namespace SparkPost.Tests
                     .CastAs<IDictionary<string, string>>()
                     ["CC"]
                     .ShouldEqual(result);
+            }
+
+            [TestCase(0)]
+            [TestCase(1)]
+            [TestCase(2)]
+            public void It_should_use_new_or_legacy_handling(int numOfTos)
+            {
+                var ccAddress = Guid.NewGuid().ToString();
+                transmission.Recipients.Add(new Recipient { Type = RecipientType.CC, Address = new Address(ccAddress) });
+
+                for (int i = 0; i < numOfTos; ++i)
+                {
+                    transmission.Recipients.Add(new Recipient { Type = RecipientType.To, Address = new Address("bob@example.com") });
+                }
+
+                var ccHeader = mapper.ToDictionary(transmission)
+                    ["content"]
+                    .CastAs<IDictionary<string, object>>()
+                    ["headers"]
+                    .CastAs<IDictionary<string, string>>()
+                    ["CC"];
+
+                if (numOfTos == 1)
+                    ccHeader.ShouldEqual(ccAddress);
+                else
+                    ccHeader.ShouldEqual($"<{ccAddress}>");
+            }
+
+            [Test]
+            public void It_should_use_legacy_handling_if_to_address_is_null()
+            {
+                var ccAddress = Guid.NewGuid().ToString();
+                transmission.Recipients.Add(new Recipient { Type = RecipientType.CC, Address = new Address(ccAddress) });
+                transmission.Recipients.Add(new Recipient { Type = RecipientType.To, Address = null });
+                
+                var ccHeader = mapper.ToDictionary(transmission)
+                    ["content"]
+                    .CastAs<IDictionary<string, object>>()
+                    ["headers"]
+                    .CastAs<IDictionary<string, string>>()
+                    ["CC"];
+
+                ccHeader.ShouldEqual($"<{ccAddress}>");
             }
         }
 

--- a/src/SparkPost/CcHandling.cs
+++ b/src/SparkPost/CcHandling.cs
@@ -13,16 +13,13 @@ namespace SparkPost
             if (recipients.All(r => r.Type == RecipientType.To))
                 return;
 
-            var toRecipientCount = recipients.Count(r => r.Type == RecipientType.To);
-
-            if (toRecipientCount == 0)
-                throw new ArgumentException("Transmission has no To recipient defined.");
-            if (toRecipientCount > 1)
-                throw new ArgumentException("Transmission has more than one To recipient defined.");
+            if (recipients.Count(r => r.Type == RecipientType.To) != 1)
+                throw new ArgumentException("There must be exactly one 'To' recipient if there are copied recipients.");
 
             var toRecipient = recipients.Single(r => r.Type == RecipientType.To);
             if (toRecipient.Address == null)
-                throw new ArgumentException("To recipient has no address.");
+                throw new ArgumentException("'To' recipient has no address.");
+
             var toName = toRecipient.Address.Name;
             var toEmail = toRecipient.Address.Email;
 

--- a/src/SparkPost/CcHandling.cs
+++ b/src/SparkPost/CcHandling.cs
@@ -7,36 +7,76 @@ namespace SparkPost
 {
     internal static class CcHandling
     {
-        internal static void DoStandardCcRewriting(Transmission transmission, IDictionary<string, object> result)
+        internal static void Process(Transmission transmission, IDictionary<string, object> result)
         {
             var recipients = transmission.Recipients;
-            if (recipients.All(r => r.Type == RecipientType.To))
+            if (recipients.All(RecipientTypeIsTo))
                 return;
 
-            if (recipients.Count(r => r.Type == RecipientType.To) != 1)
-                throw new ArgumentException("There must be exactly one 'To' recipient if there are copied recipients.");
+            var toRecipient = recipients.FirstOrDefault(RecipientTypeIsTo);
+            if (recipients.Count(RecipientTypeIsTo) == 1 && toRecipient.Address != null)
+                DoStandardCcRewriting(recipients, result);
+            else
+                SetAnyCCsInTheHeader(recipients, result);
+        }
 
-            var toRecipient = recipients.Single(r => r.Type == RecipientType.To);
-            if (toRecipient.Address == null)
-                throw new ArgumentException("'To' recipient has no address.");
-
+        private static void DoStandardCcRewriting(IEnumerable<Recipient> recipients, IDictionary<string, object> result)
+        {
+            var toRecipient = recipients.Single(RecipientTypeIsTo);
             var toName = toRecipient.Address.Name;
             var toEmail = toRecipient.Address.Email;
 
-            var ccRecipients = recipients.Where(r => r.Type == RecipientType.CC);
+            var ccRecipients = recipients.Where(RecipientTypeIsCC);
             if (ccRecipients.Any())
             {
                 var ccHeader = GetCcHeader(ccRecipients);
-                if (ccHeader != null)
-                {
-                    MakeSureThereIsAHeaderDefinedInTheRequest(result);
-                    SetThisHeaderValue(result, "CC", ccHeader);
-                }
+                if (!String.IsNullOrWhiteSpace(ccHeader))
+                    SetTheCcHeader(result, ccHeader);
             }
 
             var resultRecipients = (result["recipients"] as IEnumerable<IDictionary<string, object>>).ToList();
             SetFieldsOnRecipients(resultRecipients, toName, toEmail);
             result["recipients"] = resultRecipients;
+        }
+
+        private static void SetAnyCCsInTheHeader(IEnumerable<Recipient> recipients, IDictionary<string, object> result)
+        {
+            var ccs = GetTheCcEmails(recipients);
+
+            if (ccs.Any() == false) return;
+
+            string ccHeader = FormatTheCCs(ccs);
+            SetTheCcHeader(result, ccHeader);
+        }
+
+        private static IEnumerable<string> GetTheCcEmails(IEnumerable<Recipient> recipients)
+        {
+            return recipients
+                .Where(x => x.Type == RecipientType.CC)
+                .Where(x => x.Address != null)
+                .Where(x => string.IsNullOrWhiteSpace(x.Address.Email) == false)
+                .Select(x => x.Address.Email);
+        }
+
+        private static string FormatTheCCs(IEnumerable<string> ccs)
+        {
+            return string.Join(",", ccs.Select(x => "<" + x + ">"));
+        }
+
+        private static void SetTheCcHeader(IDictionary<string, object> result, string header)
+        {
+            MakeSureThereIsAHeaderDefinedInTheRequest(result);
+            SetThisHeaderValue(result, "CC", header);
+        }
+
+        private static bool RecipientTypeIsTo(Recipient recipient)
+        {
+            return recipient.Type == RecipientType.To;
+        }
+
+        private static bool RecipientTypeIsCC(Recipient recipient)
+        {
+            return recipient.Type == RecipientType.CC;
         }
 
         private static void SetFieldsOnRecipients(IEnumerable<IDictionary<string, object>> recipients,
@@ -58,11 +98,11 @@ namespace SparkPost
 
         private static string GetCcHeader(IEnumerable<Recipient> recipients)
         {
-            var listOfFormattedAddresses = recipients.Select(FormatAddress).Where(fa => !String.IsNullOrWhiteSpace(fa));
+            var listOfFormattedAddresses = recipients.Select(FormatedAddress).Where(fa => !String.IsNullOrWhiteSpace(fa));
             return listOfFormattedAddresses.Any() ? String.Join(", ", listOfFormattedAddresses) : null;
         }
 
-        private static string FormatAddress(Recipient recipient)
+        private static string FormatedAddress(Recipient recipient)
         {
             var address = recipient.Address;
             if (address == null)

--- a/src/SparkPost/CcHandling.cs
+++ b/src/SparkPost/CcHandling.cs
@@ -1,33 +1,85 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 using System.Linq;
+using System.Text.RegularExpressions;
 
 namespace SparkPost
 {
     internal static class CcHandling
     {
-        internal static void SetAnyCCsInTheHeader(Transmission transmission, IDictionary<string, object> result)
+        internal static void DoStandardCcRewriting(Transmission transmission, IDictionary<string, object> result)
         {
-            var ccs = GetTheCcEmails(transmission);
+            var recipients = transmission.Recipients;
+            if (recipients.All(r => r.Type == RecipientType.To))
+                return;
 
-            if (ccs.Any() == false) return;
+            var toRecipientCount = recipients.Count(r => r.Type == RecipientType.To);
 
-            MakeSureThereIsAHeaderDefinedInTheRequest(result);
+            if (toRecipientCount == 0)
+                throw new ArgumentException("Transmission has no To recipient defined.");
+            if (toRecipientCount > 1)
+                throw new ArgumentException("Transmission has more than one To recipient defined.");
 
-            SetThisHeaderValue(result, "CC", FormatTheCCs(ccs));
+            var toRecipient = recipients.Single(r => r.Type == RecipientType.To);
+            if (toRecipient.Address == null)
+                throw new ArgumentException("To recipient has no address.");
+            var toName = toRecipient.Address.Name;
+            var toEmail = toRecipient.Address.Email;
+
+            var ccRecipients = recipients.Where(r => r.Type == RecipientType.CC);
+            if (ccRecipients.Any())
+            {
+                var ccHeader = GetCcHeader(ccRecipients);
+                if (ccHeader != null)
+                {
+                    MakeSureThereIsAHeaderDefinedInTheRequest(result);
+                    SetThisHeaderValue(result, "CC", ccHeader);
+                }
+            }
+
+            var resultRecipients = (result["recipients"] as IEnumerable<IDictionary<string, object>>).ToList();
+            SetFieldsOnRecipients(resultRecipients, toName, toEmail);
+            result["recipients"] = resultRecipients;
         }
 
-        private static string FormatTheCCs(IEnumerable<string> ccs)
+        private static void SetFieldsOnRecipients(IEnumerable<IDictionary<string, object>> recipients,
+                string name, string email)
         {
-            return string.Join(",", ccs.Select(x => "<" + x + ">"));
+            var addresses = recipients
+                .Where(r => r.ContainsKey("address"))
+                .Select(r => r["address"])
+                .Cast<IDictionary<string, object>>();
+
+            foreach (var address in addresses)
+            {
+                if (!String.IsNullOrWhiteSpace(name))
+                    address["name"] = name;
+                if (!String.IsNullOrWhiteSpace(email))
+                    address["header_to"] = email;
+            }
         }
 
-        private static IEnumerable<string> GetTheCcEmails(Transmission transmission)
+        private static string GetCcHeader(IEnumerable<Recipient> recipients)
         {
-            return transmission.Recipients
-                .Where(x => x.Type == RecipientType.CC)
-                .Where(x => x.Address != null)
-                .Where(x => string.IsNullOrWhiteSpace(x.Address.Email) == false)
-                .Select(x => x.Address.Email);
+            var listOfFormattedAddresses = recipients.Select(FormatAddress).Where(fa => !String.IsNullOrWhiteSpace(fa));
+            return listOfFormattedAddresses.Any() ? String.Join(", ", listOfFormattedAddresses) : null;
+        }
+
+        private static string FormatAddress(Recipient recipient)
+        {
+            var address = recipient.Address;
+            if (address == null)
+                return null;
+
+            if (String.IsNullOrWhiteSpace(address.Name))
+                return address.Email;
+            else if (String.IsNullOrWhiteSpace(address.Email))
+                return null;
+            else
+            {
+                var name = Regex.IsMatch(address.Name, @"[^\w ]") ? $"\"{address.Name}\"" : address.Name;
+                return $"{name} <{address.Email}>";
+            }
         }
 
         private static void MakeSureThereIsAHeaderDefinedInTheRequest(IDictionary<string, object> result)

--- a/src/SparkPost/DataMapper.cs
+++ b/src/SparkPost/DataMapper.cs
@@ -95,7 +95,7 @@ namespace SparkPost
 
             var result = WithCommonConventions(transmission, data);
 
-            CcHandling.DoStandardCcRewriting(transmission, result);
+            CcHandling.Process(transmission, result);
 
             return result;
         }

--- a/src/SparkPost/DataMapper.cs
+++ b/src/SparkPost/DataMapper.cs
@@ -95,7 +95,7 @@ namespace SparkPost
 
             var result = WithCommonConventions(transmission, data);
 
-            CcHandling.SetAnyCCsInTheHeader(transmission, result);
+            CcHandling.DoStandardCcRewriting(transmission, result);
 
             return result;
         }


### PR DESCRIPTION
Fixes #43 

One consequence of this handling is that if there are any copied recipients (CC or BCC), there must be exactly one To recipient, and it must have an address. 

Right now I've got guard conditions in the method which throw an exception if either of these conditions is not true. I think your MO in this library tends more towards not throwing any exceptions up front and letting the API return an error if there are any issues. If you'd rather do things this way, I can adjust. Should we just not do any rewriting at all if these conditions aren't met? Or should we add the CC header but not do any address rewriting? My concern is that these will lead to odd results for which the reason may not be apparent to the user; an exception will indicate what the issue is.