### PR TITLE
Refactor for case where Email is whitespace

### DIFF
--- a/src/SparkPost/CcHandling.cs
+++ b/src/SparkPost/CcHandling.cs
@@ -108,14 +108,14 @@ namespace SparkPost
             if (address == null)
                 return null;
 
-            if (String.IsNullOrWhiteSpace(address.Name))
-                return address.Email;
-            else if (String.IsNullOrWhiteSpace(address.Email))
+            if (String.IsNullOrWhiteSpace(address.Email))
                 return null;
+            else if (String.IsNullOrWhiteSpace(address.Name))
+                return address.Email.Trim();
             else
             {
                 var name = Regex.IsMatch(address.Name, @"[^\w ]") ? $"\"{address.Name}\"" : address.Name;
-                return $"{name} <{address.Email}>";
+                return $"{name} <{address.Email.Trim()}>";
             }
         }
 


### PR DESCRIPTION
I realized after using some of this code in another project that it wasn't handling well the (edge) case where a CC recipient had an `Address.Email` that was whitespace and needed to go in the CC header. This case would in any event run into problems downstream when attempting to send to that address, but this is is a tidier way of handling the header. Nothing urgent.